### PR TITLE
Make UPR Reranker

### DIFF
--- a/KoPrivateGPT/reranker/__init__.py
+++ b/KoPrivateGPT/reranker/__init__.py
@@ -1,3 +1,4 @@
 from .llm import LLMReranker
 from .pygaggle import MonoT5Reranker
 from .tart import TARTReranker
+from .upr import UPRReranker

--- a/KoPrivateGPT/reranker/upr/__init__.py
+++ b/KoPrivateGPT/reranker/upr/__init__.py
@@ -1,0 +1,1 @@
+from .upr import UPRReranker

--- a/KoPrivateGPT/reranker/upr/upr.py
+++ b/KoPrivateGPT/reranker/upr/upr.py
@@ -1,0 +1,75 @@
+from typing import List
+
+import torch
+from transformers import T5ForConditionalGeneration, T5Tokenizer
+
+from KoPrivateGPT.reranker.base import BaseReranker
+from schema import Passage
+
+
+class UPRReranker(BaseReranker):
+    def __init__(self,
+                 model_name: str = "t5-large",
+                 prefix_prompt: str = "Passage: ",
+                 suffix_prompt: str = "Please write a question based on this passage.",
+                 use_bf16: bool = False,
+                 use_gpu: bool = False,
+                 shard_size: int = 16):
+        self.prefix_prompt = prefix_prompt
+        self.suffix_prompt = suffix_prompt
+        self.model = T5ForConditionalGeneration.from_pretrained(model_name,
+                                                                torch_dtype=torch.bfloat16 if use_bf16 else torch.float32)
+        self.tokenizer = T5Tokenizer.from_pretrained(model_name)
+        self.use_gpu = use_gpu
+        self.shard_size = shard_size
+
+    def rerank(self, query: str, passages: List[Passage]) -> List[Passage]:
+        pass
+
+    def rerank_sliding_window(self, query: str, passages: List[Passage], window_size: int) -> List[Passage]:
+        raise NotImplementedError("UPR reranker does not support sliding window reranking.")
+
+    def calculate_likelihood(self, question: str, contexts: List[str]) -> tuple[List[float], List[float]]:
+        prompts = [f"{self.prefix_prompt} {context} {self.suffix_prompt}" for context in contexts]
+        # tokenize contexts and instruction prompts
+        context_tokens = self.tokenizer(prompts,
+                                        padding='longest',
+                                        max_length=512,
+                                        pad_to_multiple_of=8,
+                                        truncation=True,
+                                        return_tensors='pt')
+        context_tensor, context_attention_mask = context_tokens.input_ids, context_tokens.attention_mask
+        if self.use_gpu:
+            context_tensor, context_attention_mask = context_tensor.cuda(), context_attention_mask.cuda()
+
+        # tokenize question
+        question_tokens = self.tokenizer([question],
+                                         max_length=128,
+                                         truncation=True,
+                                         return_tensors='pt')
+        question_tensor = question_tokens.input_ids
+        if self.use_gpu:
+            question_tensor = question_tensor.cuda()
+        question_tensor = torch.repeat_interleave(question_tensor, len(contexts), dim=0)
+
+        sharded_nll_list = []
+
+        # calculate log likelihood
+        for i in range(0, len(context_tensor), self.shard_size):
+            encoder_tensor_view = context_tensor[i: i + self.shard_size]
+            attention_mask_view = context_attention_mask[i: i + self.shard_size]
+            decoder_tensor_view = question_tensor[i: i + self.shard_size]
+            with torch.no_grad():
+                logits = self.model(input_ids=encoder_tensor_view,
+                                    attention_mask=attention_mask_view,
+                                    labels=decoder_tensor_view).logits
+
+            log_softmax = torch.nn.functional.log_softmax(logits, dim=-1)
+            nll = -log_softmax.gather(2, decoder_tensor_view.unsqueeze(2)).squeeze(2)
+
+            avg_nll = torch.sum(nll, dim=1)
+            sharded_nll_list.append(avg_nll)
+
+        topk_scores, indexes = torch.topk(-torch.cat(sharded_nll_list), k=len(context_tensor))
+
+        return indexes, topk_scores

--- a/tests/KoPrivateGPT/reranker/test_upr_reranker.py
+++ b/tests/KoPrivateGPT/reranker/test_upr_reranker.py
@@ -1,0 +1,20 @@
+import pytest
+
+from KoPrivateGPT.reranker import UPRReranker
+
+
+@pytest.fixture
+def upr_reranker():
+    reranker = UPRReranker()
+    yield reranker
+
+
+def test_calculate_likelihood(upr_reranker):
+    question = "Who is the most popular girl group in South Korea?"
+    contexts = ["The ironman in the Marvel movie once fought with Captain America.",
+                "New Jeans is the most popular girl group in South Korea.",
+                "Pizza is Italian food. It is made of flour, tomato sauce, and cheese."]
+    indexes, scores = upr_reranker.calculate_likelihood(question, contexts)
+    assert indexes[0] == 1
+    assert scores[0] > scores[1]
+    assert scores[1] > scores[2]

--- a/tests/KoPrivateGPT/reranker/test_upr_reranker.py
+++ b/tests/KoPrivateGPT/reranker/test_upr_reranker.py
@@ -1,5 +1,6 @@
 import pytest
 
+import test_base_reranker
 from KoPrivateGPT.reranker import UPRReranker
 
 
@@ -7,6 +8,14 @@ from KoPrivateGPT.reranker import UPRReranker
 def upr_reranker():
     reranker = UPRReranker()
     yield reranker
+
+
+def test_upr_reranker(upr_reranker):
+    test_passages = test_base_reranker.TEST_PASSAGES[:20]
+    query = "What is query decomposition?"
+    rerank_passages = upr_reranker.rerank(query, test_passages)
+    assert len(rerank_passages) == len(test_passages)
+    assert rerank_passages[0] != test_passages[0] or rerank_passages[-1] != test_passages[-1]
 
 
 def test_calculate_likelihood(upr_reranker):


### PR DESCRIPTION
close #104 

I made UPR Reranker. The original code is from [here](https://github.com/DevSinghSachan/unsupervised-passage-reranking). 

The support model is T5 models, like T5-lm-adapt, T0-3B or T0-11B. We don’t support gpt-neox models and others. 
You can check supported T5 model variations at [here](https://github.com/DevSinghSachan/unsupervised-passage-reranking#Results). 

The detailed explaination about UPR Reranker is at [paper](https://arxiv.org/abs/2204.07496) or our notion. 